### PR TITLE
Add Spanish support for YouTube voiceovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ MPV2 (MoneyPrinter Version 2) is, as the name suggests, the second version of th
 
 - [x] Twitter Bot (with CRON Jobs => `scheduler`)
 - [x] YouTube Shorts Automater (with CRON Jobs => `scheduler`)
+- [x] Multi-language voiceovers for YouTube Shorts (English & Spanish)
 - [x] Affiliate Marketing (Amazon + Twitter)
 - [x] Find local businesses & cold outreach
 

--- a/docs/YouTube.md
+++ b/docs/YouTube.md
@@ -19,6 +19,10 @@ In your `config.json`, you need the following attributes filled out, so that the
 }
 ```
 
+### Language support
+
+When creating a YouTube account inside the application you can now choose between English and Spanish voice-overs. Select `Spanish` (or `Español`) as the account language to generate scripts, audio narration, and subtitles in Spanish automatically.
+
 ## Roadmap
 
 Here are some features that are planned for the future:

--- a/src/classes/Tts.py
+++ b/src/classes/Tts.py
@@ -1,24 +1,22 @@
 import os
 import sys
 import site
+from typing import Dict
 
 from config import ROOT_DIR
 from TTS.utils.manage import ModelManager
 from TTS.utils.synthesizer import Synthesizer
 
-class TTS:
-    """
-    Class for Text-to-Speech using Coqui TTS.
-    """
-    def __init__(self) -> None:
-        """
-        Initializes the TTS class.
 
-        Returns:
-            None
-        """
+class TTS:
+    """Class for Text-to-Speech using Coqui TTS with multi-language support."""
+
+    def __init__(self) -> None:
+        """Initializes the TTS class and prepares language specific synthesizers."""
         # Detect virtual environment site packages
-        if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        if hasattr(sys, "real_prefix") or (
+            hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+        ):
             # We're in a virtual environment
             site_packages = site.getsitepackages()[0]
         else:
@@ -26,11 +24,7 @@ class TTS:
             site_packages = site.getusersitepackages()
 
         # Path to the .models.json file
-        models_json_path = os.path.join(
-            site_packages,
-            "TTS",
-            ".models.json",
-        )
+        models_json_path = os.path.join(site_packages, "TTS", ".models.json")
 
         # Create directory if it doesn't exist
         tts_dir = os.path.dirname(models_json_path)
@@ -40,48 +34,73 @@ class TTS:
         # Initialize the ModelManager
         self._model_manager = ModelManager(models_json_path)
 
-        # Download tts_models/en/ljspeech/fast_pitch
-        self._model_path, self._config_path, self._model_item = \
-            self._model_manager.download_model("tts_models/en/ljspeech/tacotron2-DDC_ph")
+        # Cache synthesizers to avoid re-downloading models
+        self._synthesizers: Dict[str, Synthesizer] = {}
 
-        # Download vocoder_models/en/ljspeech/hifigan_v2 as our vocoder
-        voc_path, voc_config_path, _ = self._model_manager. \
-            download_model("vocoder_models/en/ljspeech/univnet")
-        
-        # Initialize the Synthesizer
-        self._synthesizer = Synthesizer(
-            tts_checkpoint=self._model_path,
-            tts_config_path=self._config_path,
+        # Map supported languages to their Coqui model identifiers
+        self._language_models = {
+            "english": {
+                "tts": "tts_models/en/ljspeech/tacotron2-DDC_ph",
+                "vocoder": "vocoder_models/en/ljspeech/univnet",
+            },
+            "spanish": {
+                "tts": "tts_models/es/mai/tacotron2-DDC",
+                "vocoder": "vocoder_models/universal/libri-tts/fullband-multi-speaker",
+            },
+        }
+
+    def _normalize_language(self, language: str) -> str:
+        """Normalizes and validates the requested language."""
+        if not language:
+            return "english"
+
+        normalized = language.strip().lower()
+
+        if normalized in {"es", "español", "espanol", "spanish"}:
+            return "spanish"
+
+        return "english"
+
+    def _get_synthesizer(self, language: str) -> Synthesizer:
+        """Returns a synthesizer for the requested language, downloading models on demand."""
+        language_key = self._normalize_language(language)
+
+        if language_key in self._synthesizers:
+            return self._synthesizers[language_key]
+
+        model_config = self._language_models.get(language_key, self._language_models["english"])
+
+        tts_model_id = model_config["tts"]
+        vocoder_model_id = model_config["vocoder"]
+
+        tts_path, tts_config_path, _ = self._model_manager.download_model(tts_model_id)
+        voc_path, voc_config_path, _ = self._model_manager.download_model(vocoder_model_id)
+
+        synthesizer = Synthesizer(
+            tts_checkpoint=tts_path,
+            tts_config_path=tts_config_path,
             vocoder_checkpoint=voc_path,
-            vocoder_config=voc_config_path
+            vocoder_config=voc_config_path,
         )
 
-    @property
-    def synthesizer(self) -> Synthesizer:
-        """
-        Returns the synthesizer.
+        self._synthesizers[language_key] = synthesizer
+        return synthesizer
 
-        Returns:
-            Synthesizer: The synthesizer.
-        """
-        return self._synthesizer
+    def synthesize(
+        self,
+        text: str,
+        output_file: str = os.path.join(ROOT_DIR, ".mp", "audio.wav"),
+        language: str = "english",
+    ) -> str:
+        """Synthesizes the given text into speech in the requested language."""
 
-    def synthesize(self, text: str, output_file: str = os.path.join(ROOT_DIR, ".mp", "audio.wav")) -> str:
-        """
-        Synthesizes the given text into speech.
+        synthesizer = self._get_synthesizer(language)
 
-        Args:
-            text (str): The text to synthesize.
-            output_file (str, optional): The output file to save the synthesized speech. Defaults to "audio.wav".
-
-        Returns:
-            str: The path to the output file.
-        """
         # Synthesize the text
-        outputs = self.synthesizer.tts(text)
+        outputs = synthesizer.tts(text)
 
         # Save the synthesized speech to the output file
-        self.synthesizer.save_wav(outputs, output_file)
+        synthesizer.save_wav(outputs, output_file)
 
         return output_file
 

--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -436,10 +436,10 @@ class YouTube:
         """
         path = os.path.join(ROOT_DIR, ".mp", str(uuid4()) + ".wav")
 
-        # Clean script, remove every character that is not a word character, a space, a period, a question mark, or an exclamation mark.
-        self.script = re.sub(r'[^\w\s.?!]', '', self.script)
+        # Clean script, remove unsupported characters while keeping common punctuation
+        self.script = re.sub(r"[^\w\s.,?!¡¿]", "", self.script, flags=re.UNICODE)
 
-        tts_instance.synthesize(self.script, path)
+        tts_instance.synthesize(self.script, path, language=self.language)
 
         self.tts_path = path
 


### PR DESCRIPTION
## Summary
- add language-aware TTS management so Spanish voiceovers use the appropriate Coqui models
- keep Spanish punctuation while generating scripts and forward the account language to TTS synthesis
- document the new Spanish support in the README and YouTube guide

## Testing
- python -m compileall src *(fails: repo expects Python 3.9 via pyenv, which is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d854ab2f3c8320ad2ee31fda610dff